### PR TITLE
Changes from require_once to require for credentials

### DIFF
--- a/includes/include_mongo_connect.php
+++ b/includes/include_mongo_connect.php
@@ -1,6 +1,6 @@
 <?php
 
-	require_once($_SERVER['DOCUMENT_ROOT'] . "/includes/credentials.php");
+	require($_SERVER['DOCUMENT_ROOT'] . "/includes/credentials.php");
 
 	try {
 		// connect to Mongo

--- a/includes/initialize.php
+++ b/includes/initialize.php
@@ -108,7 +108,7 @@ function lookupUser($warehouse,$sql) {
 
 function warehouseLookup() {
 	include($_SERVER["DOCUMENT_ROOT"]."/includes/salt.php");
-	require_once($_SERVER['DOCUMENT_ROOT'] . "/includes/credentials.php");
+	require($_SERVER['DOCUMENT_ROOT'] . "/includes/credentials.php");
 
 	switch ($_SERVER["SERVER_NAME"]) {
 		case "oastats":


### PR DESCRIPTION
Using require_once caused authentication errors for administrators in certain specific cases.
Tagging @JPrevost for review...